### PR TITLE
single-responsibility class for card manager and dependency injection through arguments

### DIFF
--- a/card_sdk.py
+++ b/card_sdk.py
@@ -1,0 +1,33 @@
+import json
+from urllib.parse import urljoin
+
+import requests
+
+
+class CardSDK:
+    base_url: str
+    api_key: str
+
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self.base_url = base_url
+        self.api_key = api_key
+
+    def verify(self, idm: str) -> bool:
+        url = urljoin(self.base_url, "/api/card/verify")
+        payload = json.dumps({"idm": idm})
+        headers = {"X-Api-Key": self.api_key, "Content-Type": "application/json"}
+        response = requests.request("GET", url, headers=headers, data=payload)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print(e)
+            return False
+
+        try:
+            status = response.json()
+        except requests.exceptions.JSONDecodeError as e:
+            print(e)
+            return False
+
+        return status["verified"] is not None and status["verified"]

--- a/test_KM4K.py
+++ b/test_KM4K.py
@@ -2,10 +2,11 @@
 import contextlib
 import os
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, create_autospec, patch
 
-import requests_mock
 from redis import StrictRedis
+
+from card_sdk import CardSDK
 
 rpi_mock = Mock()
 nfc_mock = Mock()
@@ -32,207 +33,112 @@ class TestKM4K(TestCase):
     def tearDown(self):
         self.conn.flushdb()
 
-    def test_check_card_manager_fail_without_api_key(self):
-        from KM4K import check_card_manager
-
-        with self.assertRaises(KeyError):
-            check_card_manager("dummy")
-
-    @patch.dict(
-        "os.environ",
-        {
-            "API_KEY": "dummy",
-        },
-    )
-    def test_check_card_manager_invalid_api_key(self):
-        with requests_mock.Mocker() as m:
-            m.get(
-                "https://card.ueckoken.club/api/card/verify",
-                status_code=401,
-                reason="Unauthorized",
-                json={"error": "Unauthorized"},
-            )
-
-            from KM4K import check_card_manager
-
-            self.assertFalse(check_card_manager("dummy"))
-
-    @patch.dict(
-        "os.environ",
-        {
-            "API_KEY": "dummy",
-        },
-    )
-    def test_check_card_manager_invalid(self):
-        with requests_mock.Mocker() as m:
-            m.get(
-                "https://card.ueckoken.club/api/card/verify",
-                status_code=400,
-                reason="Bad Request",
-                json={"error": "Bad request"},
-            )
-
-            from KM4K import check_card_manager
-
-            self.assertFalse(check_card_manager("dummy"))
-
-    @patch.dict(
-        "os.environ",
-        {
-            "API_KEY": "dummy",
-        },
-    )
-    def test_check_card_manager_does_not_exist(self):
-        with requests_mock.Mocker() as m:
-            m.get(
-                "https://card.ueckoken.club/api/card/verify",
-                status_code=404,
-                reason="Not Found",
-                json={"error": "Not found"},
-            )
-
-            from KM4K import check_card_manager
-
-            self.assertFalse(check_card_manager("dummy"))
-
-    @patch.dict(
-        "os.environ",
-        {
-            "API_KEY": "dummy",
-        },
-    )
-    def test_check_card_manager_forbidden(self):
-        with requests_mock.Mocker() as m:
-            m.get(
-                "https://card.ueckoken.club/api/card/verify",
-                status_code=403,
-                reason="Forbidden",
-                json={"error": "Forbidden"},
-            )
-
-            from KM4K import check_card_manager
-
-            self.assertFalse(check_card_manager("dummy"))
-
-    @patch.dict(
-        "os.environ",
-        {
-            "API_KEY": "dummy",
-        },
-    )
-    def test_check_card_manager_verified(self):
-        with requests_mock.Mocker() as m:
-            m.get(
-                "https://card.ueckoken.club/api/card/verify",
-                status_code=200,
-                reason="OK",
-                json={"verified": True},
-            )
-
-            from KM4K import check_card_manager
-
-            self.assertTrue(check_card_manager("dummy"))
-
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", InterruptedError])
-    @patch("KM4K.check_card_manager", return_value=False)
     def test_start_system_with_closed_door_and_unregistered_card(
         self,
-        mocked_check_card_manager,  # noqa: ARG002
         mocked_read_nfc,  # noqa: ARG002
         mocked_servo,
     ):
+        card = create_autospec(CardSDK)
+        card.verify.return_value = False
+
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=False, okled_pin=19, ngled_pin=26)
+            start_system(isopen=False, okled_pin=19, ngled_pin=26, card=card)
 
         mocked_servo.unlock.assert_not_called()
         mocked_servo.lock.assert_not_called()
 
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", InterruptedError])
-    @patch("KM4K.check_card_manager", return_value=True)
     def test_start_system_with_closed_door_and_registered_card(
         self,
-        mocked_check_card_manager,  # noqa: ARG002
         mocked_read_nfc,  # noqa: ARG002
         mocked_servo,
     ):
+        card = create_autospec(CardSDK)
+        card.verify.return_value = True
+
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=False, okled_pin=19, ngled_pin=26)
+            start_system(isopen=False, okled_pin=19, ngled_pin=26, card=card)
 
         mocked_servo.unlock.assert_called_once()
         mocked_servo.lock.assert_not_called()
 
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", InterruptedError])
-    @patch("KM4K.check_card_manager", return_value=False)
     def test_start_system_with_open_door_and_unregistered_card(
         self,
-        mocked_check_card_manager,  # noqa: ARG002
         mocked_read_nfc,  # noqa: ARG002
         mocked_servo,
     ):
+        card = create_autospec(CardSDK)
+        card.verify.return_value = False
+
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=True, okled_pin=19, ngled_pin=26)
+            start_system(isopen=True, okled_pin=19, ngled_pin=26, card=card)
 
         mocked_servo.unlock.assert_not_called()
         mocked_servo.lock.assert_not_called()
 
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", InterruptedError])
-    @patch("KM4K.check_card_manager", return_value=True)
     def test_start_system_with_open_door_and_registered_card(
         self,
-        mocked_check_card_manager,  # noqa: ARG002
         mocked_read_nfc,  # noqa: ARG002
         mocked_servo,
     ):
+        card = create_autospec(CardSDK)
+        card.verify.return_value = True
+
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=True, okled_pin=19, ngled_pin=26)
+            start_system(isopen=True, okled_pin=19, ngled_pin=26, card=card)
 
         mocked_servo.unlock.assert_not_called()
         mocked_servo.lock.assert_called_once()
 
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", b"345678", InterruptedError])
-    @patch("KM4K.check_card_manager", return_value=True)
     def test_start_system_with_redis_cache(
         self,
-        mocked_check_card_manager,
         mocked_read_nfc,  # noqa: ARG002
         mocked_servo,
     ):
+        card = create_autospec(CardSDK)
+        card.verify.return_value = True
+
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=True, okled_pin=19, ngled_pin=26)
+            start_system(isopen=True, okled_pin=19, ngled_pin=26, card=card)
 
         mocked_servo.unlock.assert_called_once()
         mocked_servo.lock.assert_called_once()
-        mocked_check_card_manager.assert_called_once()
+        card.verify.assert_called_once()
 
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"456789", b"456789", InterruptedError])
-    @patch("KM4K.check_card_manager", side_effect=[True, False])
     def test_start_system_unregistered_card_with_redis_cache(
         self,
-        mocked_check_card_manager,
         mocked_read_nfc,  # noqa: ARG002
         mocked_servo,
     ):
+        card = create_autospec(CardSDK)
+        card.verify.side_effect = [True, False]
+
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=True, okled_pin=19, ngled_pin=26)
+            start_system(isopen=True, okled_pin=19, ngled_pin=26, card=card)
 
         mocked_servo.unlock.assert_called_once()
         mocked_servo.lock.assert_called_once()
-        mocked_check_card_manager.assert_called_once()
+        card.verify.assert_called_once()

--- a/test_card_sdk.py
+++ b/test_card_sdk.py
@@ -1,0 +1,73 @@
+# ruff: noqa: S101
+from unittest import TestCase
+
+import requests_mock
+
+from card_sdk import CardSDK
+
+
+class TestCardSDK(TestCase):
+    def test_verify_invalid_api_key(self):
+        card = CardSDK("https://card.ueckoken.club", "dummy_api_key")
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://card.ueckoken.club/api/card/verify",
+                status_code=401,
+                reason="Unauthorized",
+                json={"error": "Unauthorized"},
+            )
+
+            self.assertFalse(card.verify("dummy_idm"))
+
+    def test_verify_invalid_request(self):
+        card = CardSDK("https://card.ueckoken.club", "dummy_api_key")
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://card.ueckoken.club/api/card/verify",
+                status_code=400,
+                reason="Bad Request",
+                json={"error": "Bad request"},
+            )
+
+            self.assertFalse(card.verify("dummy_idm"))
+
+    def test_verify_does_not_exist(self):
+        card = CardSDK("https://card.ueckoken.club", "dummy_api_key")
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://card.ueckoken.club/api/card/verify",
+                status_code=404,
+                reason="Not Found",
+                json={"error": "Not found"},
+            )
+
+            self.assertFalse(card.verify("dummy_idm"))
+
+    def test_verify_forbidden(self):
+        card = CardSDK("https://card.ueckoken.club", "dummy_api_key")
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://card.ueckoken.club/api/card/verify",
+                status_code=403,
+                reason="Forbidden",
+                json={"error": "Forbidden"},
+            )
+
+            self.assertFalse(card.verify("dummy_idm"))
+
+    def test_verify_verified(self):
+        card = CardSDK("https://card.ueckoken.club", "dummy_api_key")
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://card.ueckoken.club/api/card/verify",
+                status_code=200,
+                reason="OK",
+                json={"verified": True},
+            )
+
+            self.assertTrue(card.verify("dummy_idm"))


### PR DESCRIPTION
- ハードコーディングな `check_card_manager` メソッドの代わりにCard Managerとの通信を担う単一責任のクラスを作成
- `start_system` の外側でインスタンス化して引数で渡すことで依存性注入