### PR TITLE
dependency injection for Redis

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -7,3 +7,7 @@ services:
   km4k:
     build:
       dockerfile: Dockerfile.dev
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 0

--- a/test_KM4K.py
+++ b/test_KM4K.py
@@ -145,7 +145,7 @@ class TestKM4K(TestCase):
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=False, okled_pin=19, ngled_pin=26)
+            start_system(isopen=False, okled_pin=19, ngled_pin=26, cache=self.conn)
 
         mocked_servo.unlock.assert_not_called()
         mocked_servo.lock.assert_not_called()
@@ -162,7 +162,7 @@ class TestKM4K(TestCase):
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=False, okled_pin=19, ngled_pin=26)
+            start_system(isopen=False, okled_pin=19, ngled_pin=26, cache=self.conn)
 
         mocked_servo.unlock.assert_called_once()
         mocked_servo.lock.assert_not_called()
@@ -179,7 +179,7 @@ class TestKM4K(TestCase):
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=True, okled_pin=19, ngled_pin=26)
+            start_system(isopen=True, okled_pin=19, ngled_pin=26, cache=self.conn)
 
         mocked_servo.unlock.assert_not_called()
         mocked_servo.lock.assert_not_called()
@@ -196,7 +196,7 @@ class TestKM4K(TestCase):
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=True, okled_pin=19, ngled_pin=26)
+            start_system(isopen=True, okled_pin=19, ngled_pin=26, cache=self.conn)
 
         mocked_servo.unlock.assert_not_called()
         mocked_servo.lock.assert_called_once()
@@ -213,7 +213,7 @@ class TestKM4K(TestCase):
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=True, okled_pin=19, ngled_pin=26)
+            start_system(isopen=True, okled_pin=19, ngled_pin=26, cache=self.conn)
 
         mocked_servo.unlock.assert_called_once()
         mocked_servo.lock.assert_called_once()
@@ -231,7 +231,7 @@ class TestKM4K(TestCase):
         from KM4K import start_system
 
         with contextlib.suppress(InterruptedError):
-            start_system(isopen=True, okled_pin=19, ngled_pin=26)
+            start_system(isopen=True, okled_pin=19, ngled_pin=26, cache=self.conn)
 
         mocked_servo.unlock.assert_called_once()
         mocked_servo.lock.assert_called_once()


### PR DESCRIPTION
- StrictRedisを `start_system` の外側でインスタンス化して引数で渡すことで依存性注入