### PR TITLE
externalize authentication logic and add interface to verify

### DIFF
--- a/card_verifier_interface.py
+++ b/card_verifier_interface.py
@@ -1,0 +1,6 @@
+from typing_extensions import Protocol
+
+
+class CardVerifierInterface(Protocol):
+    def verify(self, idm: str) -> bool:
+        ...

--- a/redis_cache_aside_card_verifier.py
+++ b/redis_cache_aside_card_verifier.py
@@ -1,0 +1,34 @@
+from redis import Redis
+
+from card_verifier_interface import CardVerifierInterface
+
+
+class RedisCacheAsideCardVerifier:
+    verifier: CardVerifierInterface
+    cache: Redis
+    expire_in: int
+
+    def __init__(
+        self,
+        verifier: CardVerifierInterface,
+        cache: Redis,
+        expire_in: int,
+    ):
+        super().__init__()
+        self.verifier = verifier
+        self.cache = cache
+        self.expire_in = expire_in
+
+    def verify(self, idm: str) -> bool:
+        # Redisに登録されているか確認
+        if self.cache.get(idm) is not None:
+            return True
+
+        verified = self.verifier.verify(idm)
+        if not verified:
+            return False
+
+        # 有効期限付きでRedisに保存
+        # 値は今のところ使わないので適当に1にしておいた
+        self.cache.set(idm, 1, ex=self.expire_in)
+        return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ RPi.GPIO==0.7.0; platform_machine == 'armv6l'
 wiringpi==2.60.1; platform_machine == 'armv6l'
 requests==2.18.4
 redis==4.5.4
+typing-extensions==4.7.1

--- a/test_redis_cached_card_verifier.py
+++ b/test_redis_cached_card_verifier.py
@@ -1,0 +1,70 @@
+# ruff: noqa: S101
+import os
+import time
+from unittest import TestCase
+from unittest.mock import create_autospec
+
+from redis import StrictRedis
+
+from card_verifier_interface import CardVerifierInterface
+from redis_cache_aside_card_verifier import RedisCacheAsideCardVerifier
+
+
+class TestRedisCachedCardVerifier(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.cache = StrictRedis(
+            host=os.environ["REDIS_HOST"],
+            port=os.environ["REDIS_PORT"],
+            db=os.environ["REDIS_DB"],
+        )
+        self.verifier = create_autospec(CardVerifierInterface)
+        self.cached_verifier = RedisCacheAsideCardVerifier(
+            self.verifier,
+            self.cache,
+            5,
+        )
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.cache.flushdb()
+
+    def test_cache_miss_verified(self):
+        self.verifier.verify.return_value = True
+        self.assertTrue(self.cached_verifier.verify("345678"))
+        self.verifier.verify.assert_called_once()
+
+    def test_cache_miss_invalid(self):
+        self.verifier.verify.return_value = False
+        self.assertFalse(self.cached_verifier.verify("345678"))
+        self.verifier.verify.assert_called_once()
+
+    def test_cache_hit_verified(self):
+        self.verifier.verify.return_value = True
+        self.cached_verifier.verify("345678")  # init cache
+        self.verifier.verify.assert_called_once()  # called first
+        self.assertTrue(self.cached_verifier.verify("345678"))
+        self.verifier.verify.assert_called_once()  # not called again
+
+    def test_cache_hit_invalid(self):
+        self.verifier.verify.return_value = False
+        self.cached_verifier.verify("345678")  # init cache
+        self.verifier.verify.assert_called_once()  # called first
+        self.assertFalse(self.cached_verifier.verify("345678"))
+        self.assertEqual(self.verifier.verify.call_count, 2)  # called again
+
+    def test_cache_expire(self):
+        self.verifier.verify.return_value = True
+        self.cached_verifier.verify("345678")  # init cache
+        self.verifier.verify.assert_called_once()  # called first
+        time.sleep(self.cached_verifier.expire_in)  # wait for expiration
+        self.assertTrue(self.cached_verifier.verify("345678"))
+        self.assertEqual(self.verifier.verify.call_count, 2)  # called again
+
+    def test_obsoleted_cache_hit(self):
+        self.verifier.verify.return_value = True
+        self.cached_verifier.verify("345678")  # init cache
+        self.verifier.verify.return_value = False  # changes
+        self.assertTrue(
+            self.cached_verifier.verify("345678"),
+        )  # still returns obsoleted result


### PR DESCRIPTION
- `start_system` 内にあった認証ロジックをクラス `RedisCacheAsideCardVerifier` として独立させる
- 認証のためのインターフェース `CardVerifierInterface` を追加

これにより

- `start_system` には `CardVerifierInterface` を満たす任意の認証の実装を注入可能
- `RedisCacheAsideCardVerifier` もまた `CardVerifierInterface` を満たす任意の認証の実装を注入可能
- ついでにテストがよりシンプルに

なおこの方法を使えばキャッシュの実装も抽象化できるが、ひとまずこのPRのスコープ外ということにした