### PR TITLE
pin pip to the current latest version

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,8 @@ FROM debian:buster-slim
 
 RUN apt-get update \
   && apt-get install -y libusb-1.0-0 python3 python3-pip \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && python3 -m pip install pip==23.2.1
 
 WORKDIR /app
 COPY requirements*.txt /app/


### PR DESCRIPTION
ruff requires newer pip