### PR TITLE
do not hard-code API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ systemctl status KM4K2
 
 ### 環境変数
 
-- `VERIFY_API_URL` : CardManagerのカード認証用エンドポイント
+- `CARD_MANAGER_BASE_URL` : CardManagerのAPIベースURL
 - `API_KEY` : CardManagerのAPI-Key
 - `REDIS_HOST` : Redisサーバーのホスト名
 - `REDIS_PORT` : Redisサーバーのポート番号

--- a/km4k2/__main__.py
+++ b/km4k2/__main__.py
@@ -23,7 +23,7 @@ def main():
         port=os.environ["REDIS_PORT"],
         db=os.environ["REDIS_DB"],
     )
-    api_verifier = CardSDK("https://card.ueckoken.club", os.environ["API_KEY"])
+    api_verifier = CardSDK(os.environ["CARD_MANAGER_BASE_URL"], os.environ["API_KEY"])
     redis_cached_api_verifier = RedisCacheAsideCardVerifier(
         api_verifier,
         conn,


### PR DESCRIPTION
READMEに書かれてた `VERIFY_API_URL` が実は使われてなかったのを見つけたので、代わりに `CARD_MANAGER_BASE_URL` として実装